### PR TITLE
Maui-Replaced Default Search Bar with SfEntry in MainPage of Book-Library App.

### DIFF
--- a/ListviewMAUI/Helper/ListViewSearchBehavior.cs
+++ b/ListviewMAUI/Helper/ListViewSearchBehavior.cs
@@ -5,7 +5,7 @@
         #region Fields
 
         private Syncfusion.Maui.ListView.SfListView ListView;
-        private SearchBar searchBar = null;
+        private Entry searchBar = null;
 
         #endregion
 
@@ -13,7 +13,7 @@
         protected override void OnAttachedTo(ContentPage bindable)
         {
             ListView = ListView = bindable.FindByName<Syncfusion.Maui.ListView.SfListView>("listView");
-            searchBar = bindable.FindByName<SearchBar>("searchBar");          
+            searchBar = bindable.FindByName<Entry>("searchBar");          
             searchBar.TextChanged += SearchBar_TextChanged;
 
             base.OnAttachedTo(bindable);
@@ -29,7 +29,7 @@
 
         private void SearchBar_TextChanged(object sender, TextChangedEventArgs e)
         {
-            searchBar = (sender as SearchBar);
+            searchBar = (sender as Entry);
             if (ListView.DataSource != null)
             {
                 ListView.DataSource.Filter = FilterBooks;

--- a/ListviewMAUI/Views/MainPage.xaml
+++ b/ListviewMAUI/Views/MainPage.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:syncfusion="clr-namespace:Syncfusion.Maui.ListView;assembly=Syncfusion.Maui.ListView"
              xmlns:local="clr-namespace:ListViewMAUI"
+             xmlns:entry="clr-namespace:ListViewMAUI.Helper"
              x:Class="ListViewMAUI.MainPage">
 
     <ContentPage.BindingContext>
@@ -19,19 +20,44 @@
         </Grid.RowDefinitions>
 
         <Grid ColumnDefinitions="*,40">
-            <SearchBar x:Name="searchBar" Grid.Column="0"/>
+            <Border StrokeThickness="1"
+                    BackgroundColor="White"
+               Margin="8,8,0,8"
+               StrokeShape="RoundRectangle 8">
+                <Grid ColumnDefinitions="Auto,*"
+             Margin="0,0,8,0">
+                    <Label Text="&#xe728;"
+          FontFamily="MauiSampleFontIcon"
+          VerticalOptions="Center"
+          HorizontalOptions="Center"
+          FontSize="16"
+          Margin="10,0,12,0" />
+                    <entry:SfEntry  x:Name="searchBar"
+       Grid.Column="1" 
+       BackgroundColor="Transparent"
+       VerticalTextAlignment="{OnPlatform Default=Start, MacCatalyst=Center, iOS=Center}"
+       FontFamily="Roboto-Regular"
+       FontSize="16"
+       HeightRequest="38"
+       ClearButtonVisibility="Never" />
+                </Grid>
+            </Border>
+
             <Label Text="&#xe754;"           
-                        VerticalOptions="Center"
-                        HorizontalOptions="Center"
-                FontFamily="MauiSampleFontIcon"          
-                TextColor="{StaticResource Primary}"        
-                    Grid.Column="1"
-                FontSize="Medium" >
+                   VerticalOptions="Center"
+                   HorizontalOptions="Center"
+           FontFamily="MauiSampleFontIcon"          
+           TextColor="{StaticResource Primary}"        
+               Grid.Column="1"
+           FontSize="Medium" >
                 <Label.GestureRecognizers>
                     <TapGestureRecognizer Command="{Binding CreateBookCommand}"/>
                 </Label.GestureRecognizers>
             </Label>
         </Grid>
+
+
+
 
         <syncfusion:SfListView x:Name="listView"
                 AutoFitMode="Height"

--- a/ListviewMAUI/Views/MainPage.xaml
+++ b/ListviewMAUI/Views/MainPage.xaml
@@ -56,9 +56,6 @@
             </Label>
         </Grid>
 
-
-
-
         <syncfusion:SfListView x:Name="listView"
                 AutoFitMode="Height"
                 ItemSize="200"			 


### PR DESCRIPTION
### Description:
The default search bar in the MainPage has been replaced with the SfEntry control from the Syncfusion library to enhance UI consistency and customization.
   - Removed the default search bar component
   - Integrated SfEntry with existing search logic
   - Applied styling to match the app’s design language
   - Verified functionality and layout responsiveness
   
### Screen Shot:
#### Windows:
![image](https://github.com/user-attachments/assets/fe6f5f9e-9215-4d7e-9900-4ad207048ab5)

#### Android:
![image](https://github.com/user-attachments/assets/62c9e275-287f-44b7-bb4e-76b06fc114da)

#### Mac:
![image](https://github.com/user-attachments/assets/404c66a1-3aad-4502-af93-4cbf32c25a32)


   