### PR TITLE
Maui - Resolved iOS Book Image Display Issue.

### DIFF
--- a/ListviewMAUI/ListViewMAUI.csproj
+++ b/ListviewMAUI/ListViewMAUI.csproj
@@ -40,20 +40,20 @@
 
 	<ItemGroup>
 		<!-- App Icon -->
-		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />
+		<MauiIcon Include="Resources/AppIcon/appicon.svg" ForegroundFile="Resources/AppIcon/appiconfg.svg" Color="#512BD4" />
 
 		<!-- Splash Screen -->
-		<MauiSplashScreen Include="Resources\Splash\splash.svg" Color="#512BD4" BaseSize="128,128" />
+		<MauiSplashScreen Include="Resources/Splash/splash.svg" Color="#512BD4" BaseSize="128,128" />
 
 		<!-- Images -->
-		<MauiImage Include="Resources\Images\*" />
-		<MauiImage Update="Resources\Images\dotnet_bot.png" Resize="True" BaseSize="300,185" />
+		<MauiImage Include="Resources/Images/*" />
+		<MauiImage Update="Resources/Images/dotnet_bot.png" Resize="True" BaseSize="300,185" />
 
 		<!-- Custom Fonts -->
-		<MauiFont Include="Resources\Fonts\*" />
+		<MauiFont Include="Resources/Fonts/*" />
 
 		<!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
-		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+		<MauiAsset Include="Resources/Raw/**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ListviewMAUI/Model/BookInfoRepository.cs
+++ b/ListviewMAUI/Model/BookInfoRepository.cs
@@ -25,7 +25,7 @@ namespace ListViewMAUI
                     Name = BookNames[i],
                     Description = BookDescriptions[i],
                     Author = BookAuthers[i],
-                    Image = "Book" + i + ".png"
+                    Image = "book" + i + ".png"
                 };
                 bookInfo.Add(book);
             }


### PR DESCRIPTION
### Description:
Fixed an issue where book images were not displaying on iOS devices. The problem was caused by a mismatch in image file naming. The code was using Image = "Book" + i + ".png", but the actual image files were named with a lowercase "b" (e.g., book1.png, book2.png, etc.).

Updating the code to use lowercase (book) resolved the issue.

### Screen Shot:
![image](https://github.com/user-attachments/assets/03851c36-d382-42de-b9d9-8154ccbbe5c5)
